### PR TITLE
fix note on event

### DIFF
--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiParser.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiParser.java
@@ -565,11 +565,11 @@ public final class BleMidiParser {
                         @Override
                         public void run() {
                             if (midiInputEventListener != null) {
-                                if (getArg3() == 0) {
-                                    midiInputEventListener.onMidiNoteOff(sender, getArg1() & 0xf, getArg2(), getArg3());
-                                } else {
+//                                if (getArg3() == 0) {
+//                                    midiInputEventListener.onMidiNoteOff(sender, getArg1() & 0xf, getArg2(), getArg3());
+//                                } else {
                                     midiInputEventListener.onMidiNoteOn(sender, getArg1() & 0xf, getArg2(), getArg3());
-                                }
+//                               }
                             }
                         }
                     });


### PR DESCRIPTION
Hello, after the test, I found that when some pianos key down, the MidiEventVelocity may be 0, but it still belongs to the note on event

The corresponding messages received are 80, 80, 80, 43, 00