### PR TITLE
Fixed: MIDI sending doesn't work

### DIFF
--- a/BLE-MIDI-library/build.gradle
+++ b/BLE-MIDI-library/build.gradle
@@ -4,16 +4,16 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 33
+        targetSdkVersion 34
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/BLE-MIDI-library/build.gradle
+++ b/BLE-MIDI-library/build.gradle
@@ -16,9 +16,17 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    defaultConfig {
+        consumerProguardFiles 'proguard-rules.pro'
+    }
+
     buildTypes {
-        release {
+        debug {
             minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        release {
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/BLE-MIDI-library/proguard-rules.pro
+++ b/BLE-MIDI-library/proguard-rules.pro
@@ -1,17 +1,29 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Applications/Android Studio 0.8.app/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+-keep public class jp.kshoji.blemidi.** {
+    public protected *;
+}
+-keep public class jp.kshoji.javax.sound.midi.** {
+    public protected *;
+}
+-keep public class jp.kshoji.unity.midi.** {
+    public protected *;
+}
 
-# Add any project specific keep options here:
+-keepparameternames
+-renamesourcefileattribute SourceFile
+-keepattributes Signature,Exceptions,*Annotation*,
+                InnerClasses,PermittedSubclasses,EnclosingMethod,
+                Deprecated,SourceFile,LineNumberTable
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keepclassmembers,allowoptimization enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/central/BleMidiCallback.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/central/BleMidiCallback.java
@@ -789,10 +789,13 @@ public final class BleMidiCallback extends BluetoothGattCallback {
 
         @Override
         public void transferData(@NonNull byte[] writeBuffer) throws SecurityException {
-            midiOutputCharacteristic.setValue(writeBuffer);
-
             try {
-                bluetoothGatt.writeCharacteristic(midiOutputCharacteristic);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    bluetoothGatt.writeCharacteristic(midiOutputCharacteristic, writeBuffer, BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
+                } else {
+                    midiOutputCharacteristic.setValue(writeBuffer);
+                    bluetoothGatt.writeCharacteristic(midiOutputCharacteristic);
+                }
             } catch (Throwable ignored) {
                 // android.os.DeadObjectException will be thrown
                 // ignore it

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/device/MidiOutputDevice.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/device/MidiOutputDevice.java
@@ -76,7 +76,7 @@ public abstract class MidiOutputDevice {
 
             while (true) {
                 // running
-                while (!transferDataThreadAlive && isRunning) {
+                while (transferDataThreadAlive && isRunning) {
                     synchronized (transferDataStream) {
                         if (writtenDataCount > 0) {
                             transferData(transferDataStream.toByteArray());
@@ -167,6 +167,8 @@ public abstract class MidiOutputDevice {
                 writtenDataCount += data.length;
             } catch (IOException ignored) {
             }
+
+            transferDataThread.interrupt();
         }
     }
 

--- a/UnityPlayerMock/build.gradle
+++ b/UnityPlayerMock/build.gradle
@@ -1,16 +1,16 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 33
+        targetSdkVersion 34
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
 #android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip

--- a/sample-wear/build.gradle
+++ b/sample-wear/build.gradle
@@ -1,19 +1,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "jp.kshoji.blemidi.sample"
         minSdkVersion 22
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 3
         versionName "1.2"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {
@@ -37,5 +37,6 @@ dependencies {
     implementation project(':BLE-MIDI-library')
     implementation 'com.google.android.support:wearable:2.9.0'
     compileOnly 'com.google.android.wearable:wearable:2.9.0'
-    implementation 'com.google.android.gms:play-services-wearable:18.0.0'
+    implementation 'com.google.android.gms:play-services-wearable:18.1.0'
+    api 'com.android.support:support-annotations:28.0.0'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,19 +1,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "jp.kshoji.blemidi.sample"
         minSdkVersion 18
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 3
         versionName "1.2"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {


### PR DESCRIPTION
Degraded at #28 
commit: https://github.com/kshoji/BLE-MIDI-for-Android/pull/28/commits/6839f0656b6032fadf723c59f7f69b0007cd70c9

The flag `transferDataThreadAlive` was mishandled.