### PR TITLE
Fix oversized BLE packets when congested

### DIFF
--- a/BLE-MIDI-library/build.gradle
+++ b/BLE-MIDI-library/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation 'androidx.games:games-activity:4.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     api fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.13.2'
 }
 
 publishing {

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/central/BleMidiCallback.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/central/BleMidiCallback.java
@@ -9,7 +9,6 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothProfile;
-import android.bluetooth.BluetoothStatusCodes;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -37,6 +36,7 @@ import jp.kshoji.blemidi.listener.OnMidiDeviceAttachedListener;
 import jp.kshoji.blemidi.listener.OnMidiDeviceDetachedListener;
 import jp.kshoji.blemidi.listener.OnMidiInputEventListener;
 import jp.kshoji.blemidi.util.BleMidiDeviceUtils;
+import jp.kshoji.blemidi.util.BleMidiGattWriter;
 import jp.kshoji.blemidi.util.BleMidiParser;
 import jp.kshoji.blemidi.util.BleUuidUtils;
 import jp.kshoji.blemidi.util.Constants;
@@ -922,8 +922,12 @@ public final class BleMidiCallback extends BluetoothGattCallback {
         public boolean transferData(@NonNull byte[] writeBuffer) throws SecurityException {
             try {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    int result = bluetoothGatt.writeCharacteristic(midiOutputCharacteristic, writeBuffer, BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
-                    return result == BluetoothStatusCodes.SUCCESS;
+                    return BleMidiGattWriter.writeWithCongestionRetry(new BleMidiGattWriter.GattWrite() {
+                        @Override
+                        public int execute() {
+                            return bluetoothGatt.writeCharacteristic(midiOutputCharacteristic, writeBuffer, BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
+                        }
+                    });
                 } else {
                     midiOutputCharacteristic.setValue(writeBuffer);
                     return bluetoothGatt.writeCharacteristic(midiOutputCharacteristic);

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/device/MidiOutputDevice.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/device/MidiOutputDevice.java
@@ -2,8 +2,10 @@ package jp.kshoji.blemidi.device;
 
 import androidx.annotation.NonNull;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+
+import jp.kshoji.blemidi.util.BleMidiPacketEncoder;
 
 /**
  * Represents BLE MIDI Output Device
@@ -14,7 +16,15 @@ public abstract class MidiOutputDevice {
 
     public static final int MAX_TIMESTAMP = 8192;
 
-    final ByteArrayOutputStream transferDataStream = new ByteArrayOutputStream();
+    /**
+     * Default maximum MIDI messages packed into one BLE write.
+     *
+     * @see #setMaxMessagesPerPacket(int)
+     */
+    public static final int DEFAULT_MAX_MESSAGES_PER_PACKET = BleMidiPacketEncoder.DEFAULT_MAX_MESSAGES_PER_PACKET;
+
+    private final LinkedList<BleMidiPacketEncoder.PendingMidiMessage> pendingMessages = new LinkedList<>();
+    private volatile int maxMessagesPerPacket = DEFAULT_MAX_MESSAGES_PER_PACKET;
 
     /**
      * Transfer data
@@ -62,6 +72,28 @@ public abstract class MidiOutputDevice {
      */
     public abstract int getBufferSize();
 
+    /**
+     * Obtains the maximum number of MIDI messages packed into one BLE write.
+     *
+     * @return max messages per packet
+     */
+    public final int getMaxMessagesPerPacket() {
+        return maxMessagesPerPacket;
+    }
+
+    /**
+     * Sets the maximum number of MIDI messages packed into one BLE write.
+     * Smaller values reduce loss under congestion and increase latency.
+     *
+     * @param maxMessagesPerPacket must be at least 1
+     */
+    public final void setMaxMessagesPerPacket(int maxMessagesPerPacket) {
+        if (maxMessagesPerPacket < 1) {
+            throw new IllegalArgumentException("maxMessagesPerPacket must be >= 1");
+        }
+        this.maxMessagesPerPacket = maxMessagesPerPacket;
+    }
+
     @NonNull
     @Override
     public final String toString() {
@@ -74,17 +106,32 @@ public abstract class MidiOutputDevice {
         @Override
         public void run() {
             transferDataThreadAlive = true;
+            byte[] pendingPacket = null;
+            byte[] pendingSysEx = null;
 
             while (true) {
                 // running
                 while (transferDataThreadAlive && isRunning) {
-                    synchronized (transferDataStream) {
-                        if (writtenDataCount > 0) {
-                            if (transferData(transferDataStream.toByteArray())) {
-                                // reset the stream if transfer succeed
-                                transferDataStream.reset();
-                                writtenDataCount = 0;
+                    synchronized (pendingMessages) {
+                        if (pendingPacket == null && pendingSysEx == null && !pendingMessages.isEmpty()) {
+                            if (pendingMessages.getFirst().isSystemExclusive()) {
+                                pendingSysEx = pendingMessages.removeFirst().data;
+                            } else {
+                                byte[] packed = BleMidiPacketEncoder.packChannelMessages(
+                                        pendingMessages, getBufferSize(), maxMessagesPerPacket);
+                                if (packed.length > 0) {
+                                    pendingPacket = packed;
+                                }
                             }
+                        }
+                    }
+
+                    if (pendingSysEx != null) {
+                        transferSystemExclusive(pendingSysEx);
+                        pendingSysEx = null;
+                    } else if (pendingPacket != null) {
+                        if (transferData(pendingPacket)) {
+                            pendingPacket = null;
                         }
                     }
 
@@ -146,33 +193,23 @@ public abstract class MidiOutputDevice {
     public final void terminate() {
         transferDataThreadAlive = false;
         isRunning = false;
+        synchronized (pendingMessages) {
+            pendingMessages.clear();
+        }
         transferDataThread.interrupt();
     }
 
-    transient int writtenDataCount;
     private void storeTransferData(byte[] data) {
         if (!transferDataThreadAlive || !isRunning) {
             return;
         }
 
-        synchronized (transferDataStream) {
-            long timestamp = System.currentTimeMillis() % MAX_TIMESTAMP;
-            if (writtenDataCount == 0) {
-                // Store timestamp high
-                transferDataStream.write((byte) (0x80 | ((timestamp >> 7) & 0x3f)));
-                writtenDataCount++;
-            }
-            // timestamp low
-            transferDataStream.write((byte) (0x80 | (timestamp & 0x7f)));
-            writtenDataCount++;
-            try {
-                transferDataStream.write(data);
-                writtenDataCount += data.length;
-            } catch (IOException ignored) {
-            }
-
-            transferDataThread.interrupt();
+        long timestamp = System.currentTimeMillis() % MAX_TIMESTAMP;
+        byte[] copy = Arrays.copyOf(data, data.length);
+        synchronized (pendingMessages) {
+            pendingMessages.add(new BleMidiPacketEncoder.PendingMidiMessage(copy, timestamp));
         }
+        transferDataThread.interrupt();
     }
 
     /**
@@ -211,6 +248,19 @@ public abstract class MidiOutputDevice {
      * @param systemExclusive : start with 'F0', and end with 'F7'
      */
     public final void sendMidiSystemExclusive(@NonNull byte[] systemExclusive) {
+        storeTransferData(systemExclusive);
+    }
+
+    /**
+     * Encodes and writes a SysEx message as its own BLE packets (never mixed with channel messages).
+     *
+     * @param systemExclusive start with 'F0', and end with 'F7'
+     */
+    private void transferSystemExclusive(@NonNull byte[] systemExclusive) {
+        if (systemExclusive.length == 0) {
+            return;
+        }
+
         byte[] timestampAddedSystemExclusive = new byte[systemExclusive.length + 2];
         System.arraycopy(systemExclusive, 0, timestampAddedSystemExclusive, 1, systemExclusive.length);
 
@@ -223,6 +273,9 @@ public abstract class MidiOutputDevice {
 
         // split into bufferSize bytes. BLE can't send more than (bufferSize: MTU - 3) bytes.
         int bufferSize = getBufferSize();
+        if (bufferSize <= 1) {
+            return;
+        }
         byte[] writeBuffer = new byte[bufferSize];
         for (int i = 0; i < timestampAddedSystemExclusive.length; i += (bufferSize - 1)) {
             // Don't send 0xF7 timestamp LSB inside of SysEx(MIDI parser will fail) 0x7f -> 0x7e
@@ -241,7 +294,7 @@ public abstract class MidiOutputDevice {
             writeBuffer[0] = (byte) (0x80 | ((timestamp >> 7) & 0x3f));
 
             // immediately transfer data
-            while (true) {
+            while (transferDataThreadAlive) {
                 if (transferData(writeBuffer)) {
                     break;
                 }
@@ -250,6 +303,9 @@ public abstract class MidiOutputDevice {
                     Thread.sleep(10); // BluetoothGatt.WRITE_CHARACTERISTIC_TIME_TO_WAIT
                 } catch (InterruptedException ignored) {
                 }
+            }
+            if (!transferDataThreadAlive) {
+                return;
             }
 
             timestamp = System.currentTimeMillis() % MAX_TIMESTAMP;

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/peripheral/BleMidiPeripheralProvider.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/peripheral/BleMidiPeripheralProvider.java
@@ -12,7 +12,6 @@ import android.bluetooth.BluetoothGattServerCallback;
 import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothProfile;
-import android.bluetooth.BluetoothStatusCodes;
 import android.bluetooth.le.AdvertiseCallback;
 import android.bluetooth.le.AdvertiseData;
 import android.bluetooth.le.AdvertiseSettings;
@@ -38,6 +37,7 @@ import jp.kshoji.blemidi.device.MidiOutputDevice;
 import jp.kshoji.blemidi.listener.OnMidiDeviceAttachedListener;
 import jp.kshoji.blemidi.listener.OnMidiDeviceDetachedListener;
 import jp.kshoji.blemidi.listener.OnMidiInputEventListener;
+import jp.kshoji.blemidi.util.BleMidiGattWriter;
 import jp.kshoji.blemidi.util.BleMidiParser;
 import jp.kshoji.blemidi.util.BleUuidUtils;
 import jp.kshoji.blemidi.util.Constants;
@@ -712,8 +712,12 @@ public final class BleMidiPeripheralProvider {
         public boolean transferData(@NonNull byte[] writeBuffer) throws SecurityException {
             try {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    int result = bluetoothGattServer.notifyCharacteristicChanged(bluetoothDevice, midiOutputCharacteristic, false, writeBuffer);
-                    return result == BluetoothStatusCodes.SUCCESS;
+                    return BleMidiGattWriter.writeWithCongestionRetry(new BleMidiGattWriter.GattWrite() {
+                        @Override
+                        public int execute() {
+                            return bluetoothGattServer.notifyCharacteristicChanged(bluetoothDevice, midiOutputCharacteristic, false, writeBuffer);
+                        }
+                    });
                 } else {
                     midiOutputCharacteristic.setValue(writeBuffer);
                     return bluetoothGattServer.notifyCharacteristicChanged(bluetoothDevice, midiOutputCharacteristic, false);

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiGattWriter.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiGattWriter.java
@@ -1,0 +1,63 @@
+package jp.kshoji.blemidi.util;
+
+import android.bluetooth.BluetoothStatusCodes;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+/**
+ * Helpers for GATT writes that can fail under congestion.
+ *
+ * @author K.Shoji
+ */
+public final class BleMidiGattWriter {
+    /**
+     * Max retries when {@link BluetoothStatusCodes#ERROR_GATT_WRITE_REQUEST_BUSY} is returned.
+     */
+    public static final int MAX_CONGESTION_RETRIES = 100;
+
+    /**
+     * Sleep between congestion retries, in milliseconds.
+     */
+    public static final long CONGESTION_RETRY_INTERVAL_MS = 20L;
+
+    private BleMidiGattWriter() {
+    }
+
+    /**
+     * One GATT write or notify attempt.
+     */
+    public interface GattWrite {
+        /**
+         * @return a {@link BluetoothStatusCodes} result
+         */
+        int execute();
+    }
+
+    /**
+     * Executes a GATT write and retries while the remote side is busy (status 201).
+     *
+     * @param writer performs one writeCharacteristic / notifyCharacteristicChanged
+     * @return true if the last attempt returned {@link BluetoothStatusCodes#SUCCESS}
+     */
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    public static boolean writeWithCongestionRetry(@NonNull GattWrite writer) {
+        int result = writer.execute();
+        int retry = 0;
+        while (result == BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY
+                && retry < MAX_CONGESTION_RETRIES) {
+            try {
+                Thread.sleep(CONGESTION_RETRY_INTERVAL_MS);
+            } catch (InterruptedException ignored) {
+            }
+            retry++;
+            result = writer.execute();
+        }
+        if (result == BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY) {
+            Log.d(Constants.TAG, "GATT write still busy after " + MAX_CONGESTION_RETRIES + " retries");
+        }
+        return result == BluetoothStatusCodes.SUCCESS;
+    }
+}

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiPacketEncoder.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiPacketEncoder.java
@@ -1,0 +1,128 @@
+package jp.kshoji.blemidi.util;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Encodes queued MIDI messages into BLE MIDI packets.
+ * <p>
+ * Limits the number of messages per write and never mixes SysEx with
+ * channel / system-common messages, so congested queues do not produce
+ * oversized GATT writes.
+ *
+ * @author K.Shoji
+ */
+public final class BleMidiPacketEncoder {
+    /**
+     * Default maximum MIDI messages packed into one BLE packet.
+     * Matches the working limit from
+     * <a href="https://github.com/kshoji/BLE-MIDI-for-Android/issues/40">issue #40</a>.
+     */
+    public static final int DEFAULT_MAX_MESSAGES_PER_PACKET = 6;
+
+    private BleMidiPacketEncoder() {
+    }
+
+    /**
+     * Queued MIDI message waiting to be packed.
+     */
+    public static final class PendingMidiMessage {
+        @NonNull
+        public final byte[] data;
+        public final long timestamp;
+
+        public PendingMidiMessage(@NonNull byte[] data, long timestamp) {
+            this.data = data;
+            this.timestamp = timestamp;
+        }
+
+        public boolean isSystemExclusive() {
+            return BleMidiPacketEncoder.isSystemExclusive(data);
+        }
+    }
+
+    /**
+     * @param midiMessage raw MIDI bytes
+     * @return true if the message starts with F0
+     */
+    public static boolean isSystemExclusive(@Nullable byte[] midiMessage) {
+        return midiMessage != null && midiMessage.length > 0 && (midiMessage[0] & 0xff) == 0xf0;
+    }
+
+    /**
+     * Encoded size of one MIDI message in a BLE packet.
+     *
+     * @param firstInPacket true if this is the first message (includes timestamp high)
+     * @param dataLength    MIDI payload length
+     * @return number of bytes written for this message
+     */
+    public static int encodedSize(boolean firstInPacket, int dataLength) {
+        return (firstInPacket ? 1 : 0) + 1 + dataLength;
+    }
+
+    /**
+     * Packs channel / system-common messages from the front of {@code queue}
+     * into one BLE MIDI packet.
+     * <p>
+     * Stops before SysEx, when {@code maxMessagesPerPacket} is reached, or when
+     * the next message would exceed {@code bufferSize}. Packed messages are
+     * removed from {@code queue}. SysEx at the head is left untouched.
+     *
+     * @param queue                 pending messages (consumed from the front)
+     * @param bufferSize            max BLE write size (typically MTU - 3)
+     * @param maxMessagesPerPacket  max MIDI messages in this packet
+     * @return packed packet, or an empty array if nothing could be packed
+     */
+    @NonNull
+    public static byte[] packChannelMessages(@NonNull List<PendingMidiMessage> queue,
+                                             int bufferSize,
+                                             int maxMessagesPerPacket) {
+        if (queue.isEmpty() || bufferSize <= 0 || maxMessagesPerPacket <= 0) {
+            return new byte[0];
+        }
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(Math.min(bufferSize, 256));
+        int messageCount = 0;
+
+        while (!queue.isEmpty() && messageCount < maxMessagesPerPacket) {
+            PendingMidiMessage next = queue.get(0);
+            if (next.isSystemExclusive()) {
+                break;
+            }
+
+            int additional = encodedSize(messageCount == 0, next.data.length);
+            if (stream.size() + additional > bufferSize) {
+                if (messageCount == 0) {
+                    // Single message larger than the buffer: send it alone to avoid stalling.
+                    queue.remove(0);
+                    writeMessage(stream, next, true);
+                }
+                break;
+            }
+
+            queue.remove(0);
+            writeMessage(stream, next, messageCount == 0);
+            messageCount++;
+        }
+
+        return stream.toByteArray();
+    }
+
+    private static void writeMessage(@NonNull ByteArrayOutputStream stream,
+                                     @NonNull PendingMidiMessage message,
+                                     boolean firstInPacket) {
+        long timestamp = message.timestamp;
+        if (firstInPacket) {
+            stream.write((byte) (0x80 | ((timestamp >> 7) & 0x3f)));
+        }
+        stream.write((byte) (0x80 | (timestamp & 0x7f)));
+        try {
+            stream.write(message.data);
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/BleMidiGattWriterTest.java
+++ b/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/BleMidiGattWriterTest.java
@@ -1,0 +1,42 @@
+package jp.kshoji.blemidi.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.bluetooth.BluetoothStatusCodes;
+
+import org.junit.Test;
+
+public class BleMidiGattWriterTest {
+
+    @Test
+    public void succeedsWithoutRetry() {
+        final int[] attempts = {0};
+        boolean ok = BleMidiGattWriter.writeWithCongestionRetry(new BleMidiGattWriter.GattWrite() {
+            @Override
+            public int execute() {
+                attempts[0]++;
+                return BluetoothStatusCodes.SUCCESS;
+            }
+        });
+        assertTrue(ok);
+        assertEquals(1, attempts[0]);
+    }
+
+    @Test
+    public void retriesWhileBusyThenSucceeds() {
+        final int[] attempts = {0};
+        boolean ok = BleMidiGattWriter.writeWithCongestionRetry(new BleMidiGattWriter.GattWrite() {
+            @Override
+            public int execute() {
+                attempts[0]++;
+                if (attempts[0] < 3) {
+                    return BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY;
+                }
+                return BluetoothStatusCodes.SUCCESS;
+            }
+        });
+        assertTrue(ok);
+        assertEquals(3, attempts[0]);
+    }
+}

--- a/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/BleMidiPacketEncoderTest.java
+++ b/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/BleMidiPacketEncoderTest.java
@@ -1,0 +1,115 @@
+package jp.kshoji.blemidi.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BleMidiPacketEncoderTest {
+
+    private static BleMidiPacketEncoder.PendingMidiMessage noteOn(int note, long timestamp) {
+        return new BleMidiPacketEncoder.PendingMidiMessage(
+                new byte[] {(byte) 0x90, (byte) note, 0x7f}, timestamp);
+    }
+
+    private static BleMidiPacketEncoder.PendingMidiMessage sysEx(long timestamp) {
+        return new BleMidiPacketEncoder.PendingMidiMessage(
+                new byte[] {(byte) 0xf0, 0x01, 0x02, (byte) 0xf7}, timestamp);
+    }
+
+    @Test
+    public void packSingleNoteOnIncludesHeaderAndTimestamp() {
+        List<BleMidiPacketEncoder.PendingMidiMessage> queue = new ArrayList<>();
+        queue.add(noteOn(60, 0));
+
+        byte[] packet = BleMidiPacketEncoder.packChannelMessages(queue, 20, 6);
+
+        assertArrayEquals(new byte[] {
+                (byte) 0x80, (byte) 0x80, (byte) 0x90, 60, 0x7f
+        }, packet);
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void packStopsAtMaxMessagesPerPacket() {
+        List<BleMidiPacketEncoder.PendingMidiMessage> queue = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            queue.add(noteOn(60 + i, 0));
+        }
+
+        byte[] packet = BleMidiPacketEncoder.packChannelMessages(queue, 100, 6);
+
+        // header + 6 * (timestamp-low + 3-byte note)
+        assertEquals(1 + 6 * 4, packet.length);
+        assertEquals(1, queue.size());
+        assertEquals(66, queue.get(0).data[1] & 0xff);
+    }
+
+    @Test
+    public void packStopsBeforeExceedingBufferSize() {
+        List<BleMidiPacketEncoder.PendingMidiMessage> queue = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            queue.add(noteOn(60 + i, 0));
+        }
+
+        // 4 notes = 1 + 16 = 17 bytes; 5th note would be 21 > 20
+        byte[] packet = BleMidiPacketEncoder.packChannelMessages(queue, 20, 6);
+
+        assertEquals(17, packet.length);
+        assertEquals(2, queue.size());
+    }
+
+    @Test
+    public void packDoesNotConsumeSysExAtHead() {
+        List<BleMidiPacketEncoder.PendingMidiMessage> queue = new ArrayList<>();
+        queue.add(sysEx(0));
+        queue.add(noteOn(60, 0));
+
+        byte[] packet = BleMidiPacketEncoder.packChannelMessages(queue, 20, 6);
+
+        assertEquals(0, packet.length);
+        assertEquals(2, queue.size());
+        assertTrue(queue.get(0).isSystemExclusive());
+    }
+
+    @Test
+    public void packStopsBeforeFollowingSysEx() {
+        List<BleMidiPacketEncoder.PendingMidiMessage> queue = new ArrayList<>();
+        queue.add(noteOn(60, 0));
+        queue.add(noteOn(64, 0));
+        queue.add(sysEx(0));
+        queue.add(noteOn(67, 0));
+
+        byte[] packet = BleMidiPacketEncoder.packChannelMessages(queue, 100, 6);
+
+        assertEquals(1 + 4 + 4, packet.length);
+        assertEquals(2, queue.size());
+        assertTrue(queue.get(0).isSystemExclusive());
+        assertFalse(queue.get(1).isSystemExclusive());
+    }
+
+    @Test
+    public void emptyQueueReturnsEmptyPacket() {
+        List<BleMidiPacketEncoder.PendingMidiMessage> queue = new ArrayList<>();
+        assertEquals(0, BleMidiPacketEncoder.packChannelMessages(queue, 20, 6).length);
+    }
+
+    @Test
+    public void subsequentMessageUsesTimestampLowOnly() {
+        List<BleMidiPacketEncoder.PendingMidiMessage> queue = new ArrayList<>();
+        queue.add(noteOn(60, 0x0100));
+        queue.add(noteOn(64, 0x0003));
+
+        byte[] packet = BleMidiPacketEncoder.packChannelMessages(queue, 20, 6);
+
+        assertArrayEquals(new byte[] {
+                (byte) (0x80 | 0x02), (byte) 0x80, (byte) 0x90, 60, 0x7f,
+                (byte) (0x80 | 0x03), (byte) 0x90, 64, 0x7f
+        }, packet);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Usage of the library
 
 For the detail, see the [wiki](https://github.com/kshoji/BLE-MIDI-for-Android/wiki).
 
+High-density MIDI transfer
+--------------------------
+
+When the send queue is congested, packing every pending message into one GATT write tends to drop packets. This library therefore:
+
+- Packs at most **6 MIDI messages** per BLE packet (and never exceeds the negotiated MTU / `getBufferSize()`)
+- Sends **SysEx in its own packets** (never mixed with channel messages)
+- Retries Android 13+ writes that fail with `BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY` (201)
+
+The tradeoff is a small increase in latency under load, in exchange for fewer lost notes / CCs. Tune with `MidiOutputDevice.setMaxMessagesPerPacket(int)` (smaller = more reliable, more latency).
+
 LICENSE
 =======
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
## Summary
- Fix BLE MIDI output packing under congestion (#40). Queued messages were previously flushed as one GATT write, which grew too large and dropped notes / CCs.
- Pack at most 6 MIDI messages per BLE packet, stay within the negotiated MTU, and never mix SysEx with channel messages.
- Retry Android 13+ writes that return `BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY` (201) on both Central and Peripheral.
- Thanks to @syntaro for the original patch and [midione-android](https://github.com/syntaro/midione-android).

Made with [Cursor](https://cursor.com)