### PR TITLE
Fix BLE MIDI timestamp wrap ordering

### DIFF
--- a/BLE-MIDI-library/build.gradle
+++ b/BLE-MIDI-library/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation 'androidx.games:games-activity:4.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     api fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.13.2'
 }
 
 publishing {

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiParser.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiParser.java
@@ -61,13 +61,8 @@ public final class BleMidiParser {
     private int midiState;
 
     // for Timestamp
-    private static final int MAX_TIMESTAMP = 8192;
-    private static final int BUFFER_LENGTH_MILLIS = 50;
     private int timestamp = 0;
-    private int lastTimestamp;
-    private long lastTimestampRecorded = 0;
-    private int zeroTimestampCount = 0;
-    private Boolean isTimestampAlwaysZero = null;
+    private final BleMidiTimestampCoordinator timestampCoordinator = new BleMidiTimestampCoordinator();
 
     private OnMidiInputEventListener midiInputEventListener = null;
     private final MidiInputDevice sender;
@@ -161,81 +156,13 @@ public final class BleMidiParser {
         private final byte[] array;
 
         /**
-         * Calculate `time to wait` for the event's timestamp
+         * Calculates the absolute fire time for the event's BLE MIDI timestamp.
          *
-         * @param timestamp the event's timestamp
-         * @return time to wait
+         * @param timestamp the event's 13-bit timestamp
+         * @return absolute fire time in milliseconds
          */
         private long calculateEventFireTime(final int timestamp) {
-            final long currentTimeMillis = System.currentTimeMillis();
-
-            // checks timestamp value is always zero
-            if (isTimestampAlwaysZero != null) {
-                if (isTimestampAlwaysZero) {
-                    if (timestamp != 0) {
-                        // timestamp comes with non-zero. prevent misdetection
-                        isTimestampAlwaysZero = false;
-                        zeroTimestampCount = 0;
-                        lastTimestampRecorded = 0;
-                    } else {
-                        // event fires immediately
-                        return currentTimeMillis;
-                    }
-                } else {
-                    if (timestamp == 0) {
-                        // recheck timestamp value on next time
-                        isTimestampAlwaysZero = null;
-                        zeroTimestampCount = 0;
-                        // event fires immediately
-                        return currentTimeMillis;
-                    }
-                }
-            } else {
-                if (timestamp == 0) {
-                    if (zeroTimestampCount >= 3) {
-                        // decides timestamp is always zero
-                        isTimestampAlwaysZero = true;
-                    } else {
-                        zeroTimestampCount++;
-                    }
-                    // event fires immediately
-                    return currentTimeMillis;
-                } else {
-                    isTimestampAlwaysZero = false;
-                    zeroTimestampCount = 0;
-                    lastTimestampRecorded = 0;
-                }
-            }
-
-            if (lastTimestampRecorded == 0) {
-                // first time: event fires immediately
-                lastTimestamp = timestamp;
-                lastTimestampRecorded = currentTimeMillis;
-                return currentTimeMillis;
-            }
-
-            if (currentTimeMillis - lastTimestampRecorded >= MAX_TIMESTAMP) {
-                // the event comes after long pause
-                lastTimestamp = timestamp;
-                lastTimestampRecorded = currentTimeMillis;
-                return currentTimeMillis;
-            }
-
-            final long elapsedRealtime = currentTimeMillis - lastTimestampRecorded;
-            // realTimestampPeriod: how many times MAX_TIMESTAMP passed
-            long realTimestampPeriod = (lastTimestamp + elapsedRealtime) / MAX_TIMESTAMP;
-            if (realTimestampPeriod > 0 && timestamp > 7000) {
-                realTimestampPeriod--;
-            }
-            final long lastTimestampStarted = lastTimestampRecorded - lastTimestamp;
-            // result: time to wait
-            final long result = BUFFER_LENGTH_MILLIS // buffer
-                    + lastTimestampStarted + realTimestampPeriod * MAX_TIMESTAMP + timestamp // time to fire event
-                    - currentTimeMillis; // current time
-
-            lastTimestamp = timestamp;
-            lastTimestampRecorded = currentTimeMillis;
-            return result;
+            return timestampCoordinator.calculateEventFireTime(timestamp, System.currentTimeMillis());
         }
 
         private MidiEventWithTiming(int arg1, int arg2, int arg3, byte[] array, int timestamp) {

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiTimestampCoordinator.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/BleMidiTimestampCoordinator.java
@@ -1,0 +1,120 @@
+package jp.kshoji.blemidi.util;
+
+/**
+ * Converts 13-bit BLE MIDI timestamps (0–8191) into monotonic fire times.
+ * <p>
+ * Wrap handling follows BlueZ {@code libmidi.c} {@code update_ev_timestamp}:
+ * when the timestamp goes backwards, add {@link #MAX_TIMESTAMP}, unless wall-clock
+ * elapsed is so small that the jump is treated as a stale / same-time event.
+ *
+ * @author K.Shoji
+ */
+public final class BleMidiTimestampCoordinator {
+    /**
+     * BLE MIDI 13-bit timestamp range (0–8191).
+     */
+    public static final int MAX_TIMESTAMP = 8192;
+
+    /**
+     * BlueZ uses this threshold to ignore implausibly large timestamp jumps
+     * when wall-clock elapsed is under 1 second.
+     */
+    static final int IMPLAUSIBLE_JUMP_THRESHOLD = 7000;
+
+    private int lastTimestamp;
+    private long lastTimestampRecorded;
+    private long lastFireTime;
+    private int zeroTimestampCount;
+    private Boolean isTimestampAlwaysZero;
+
+    /**
+     * Calculates the absolute fire time for a BLE MIDI timestamp.
+     *
+     * @param timestamp 13-bit BLE MIDI timestamp
+     * @param now       {@link System#currentTimeMillis()} at receive time
+     * @return absolute fire time in milliseconds (comparable to {@code now})
+     */
+    public long calculateEventFireTime(int timestamp, long now) {
+        long fireTime;
+        Long zeroFireTime = handleAlwaysZeroTimestamp(timestamp, now);
+        if (zeroFireTime != null) {
+            fireTime = zeroFireTime;
+        } else if (lastTimestampRecorded == 0 || now - lastTimestampRecorded >= MAX_TIMESTAMP) {
+            fireTime = resetTimeline(timestamp, now);
+        } else {
+            int delta = timestamp - lastTimestamp;
+            long elapsedRealtime = now - lastTimestampRecorded;
+
+            if (delta > IMPLAUSIBLE_JUMP_THRESHOLD && elapsedRealtime < 1000) {
+                delta = 0;
+            } else if (delta < 0) {
+                int wrapped = delta + MAX_TIMESTAMP;
+                if (wrapped > IMPLAUSIBLE_JUMP_THRESHOLD && elapsedRealtime < 1000) {
+                    delta = 0;
+                } else {
+                    delta = wrapped;
+                }
+            }
+
+            fireTime = lastFireTime + delta;
+            if (fireTime < lastFireTime) {
+                fireTime = lastFireTime;
+            }
+
+            lastTimestamp = timestamp;
+            lastTimestampRecorded = now;
+            lastFireTime = fireTime;
+        }
+
+        return fireTime;
+    }
+
+    /**
+     * @return fire time if this event is handled as timestamp-always-zero; otherwise null
+     */
+    private Long handleAlwaysZeroTimestamp(int timestamp, long now) {
+        if (isTimestampAlwaysZero != null) {
+            if (isTimestampAlwaysZero) {
+                if (timestamp != 0) {
+                    isTimestampAlwaysZero = false;
+                    zeroTimestampCount = 0;
+                    lastTimestampRecorded = 0;
+                    return null;
+                }
+                return recordImmediate(now);
+            }
+            if (timestamp == 0) {
+                isTimestampAlwaysZero = null;
+                zeroTimestampCount = 0;
+                return recordImmediate(now);
+            }
+            return null;
+        }
+
+        if (timestamp == 0) {
+            if (zeroTimestampCount >= 3) {
+                isTimestampAlwaysZero = true;
+            } else {
+                zeroTimestampCount++;
+            }
+            return recordImmediate(now);
+        }
+
+        isTimestampAlwaysZero = false;
+        zeroTimestampCount = 0;
+        lastTimestampRecorded = 0;
+        return null;
+    }
+
+    private long resetTimeline(int timestamp, long now) {
+        lastTimestamp = timestamp;
+        lastTimestampRecorded = now;
+        lastFireTime = Math.max(now, lastFireTime);
+        return lastFireTime;
+    }
+
+    private long recordImmediate(long now) {
+        lastFireTime = Math.max(now, lastFireTime);
+        return lastFireTime;
+    }
+}

--- a/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/BleMidiTimestampCoordinatorTest.java
+++ b/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/BleMidiTimestampCoordinatorTest.java
@@ -1,0 +1,92 @@
+package jp.kshoji.blemidi.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class BleMidiTimestampCoordinatorTest {
+
+    @Test
+    public void noWrapKeepsDelta() {
+        BleMidiTimestampCoordinator coordinator = new BleMidiTimestampCoordinator();
+        long t0 = 1_000_000L;
+
+        long first = coordinator.calculateEventFireTime(100, t0);
+        long second = coordinator.calculateEventFireTime(250, t0 + 150);
+
+        assertEquals(t0, first);
+        assertEquals(first + 150, second);
+        assertTrue(second > first);
+    }
+
+    @Test
+    public void wrapFrom8000To5000IsMonotonic() {
+        BleMidiTimestampCoordinator coordinator = new BleMidiTimestampCoordinator();
+        long t0 = 1_000_000L;
+
+        long first = coordinator.calculateEventFireTime(8000, t0);
+        // Issue #19: 8192 - 8000 + 5000 = 5192 ms after the previous event
+        long second = coordinator.calculateEventFireTime(5000, t0 + 5192);
+
+        assertEquals(t0, first);
+        assertEquals(first + 5192, second);
+        assertTrue(second > first);
+    }
+
+    @Test
+    public void wrapWithBunchedArrivalStillSchedulesForward() {
+        BleMidiTimestampCoordinator coordinator = new BleMidiTimestampCoordinator();
+        long t0 = 1_000_000L;
+
+        long first = coordinator.calculateEventFireTime(8000, t0);
+        long second = coordinator.calculateEventFireTime(5000, t0 + 100);
+
+        assertEquals(first + 5192, second);
+        assertTrue(second > first);
+    }
+
+    @Test
+    public void longPauseResetsAndStaysMonotonic() {
+        BleMidiTimestampCoordinator coordinator = new BleMidiTimestampCoordinator();
+        long t0 = 1_000_000L;
+
+        long first = coordinator.calculateEventFireTime(100, t0);
+        long later = t0 + BleMidiTimestampCoordinator.MAX_TIMESTAMP;
+        long second = coordinator.calculateEventFireTime(200, later);
+
+        assertEquals(later, second);
+        assertTrue(second >= first);
+    }
+
+    @Test
+    public void alwaysZeroTimestampsFireImmediatelyAndStayMonotonic() {
+        BleMidiTimestampCoordinator coordinator = new BleMidiTimestampCoordinator();
+        long t0 = 1_000_000L;
+        long previous = Long.MIN_VALUE;
+
+        for (int i = 0; i < 6; i++) {
+            long fireTime = coordinator.calculateEventFireTime(0, t0 + i);
+            assertTrue(fireTime >= t0 + i);
+            assertTrue(fireTime >= previous);
+            previous = fireTime;
+        }
+    }
+
+    @Test
+    public void nonZeroAfterAlwaysZeroResetsTimeline() {
+        BleMidiTimestampCoordinator coordinator = new BleMidiTimestampCoordinator();
+        long t0 = 1_000_000L;
+
+        for (int i = 0; i < 4; i++) {
+            coordinator.calculateEventFireTime(0, t0 + i);
+        }
+
+        long firstNonZero = coordinator.calculateEventFireTime(100, t0 + 10);
+        long secondNonZero = coordinator.calculateEventFireTime(150, t0 + 60);
+
+        assertTrue(firstNonZero >= t0 + 10);
+        assertEquals(firstNonZero + 50, secondNonZero);
+        assertTrue(secondNonZero > firstNonZero);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix BLE MIDI input event ordering when the 13-bit timestamp wraps (#19). Example: `lastTimestamp=8000` then `timestamp=5000` must schedule +5192 ms, not a time in the past.
- Always return an absolute fire time (the previous path mixed absolute times with wait durations, which reversed queue order).
- Wrap correction follows BlueZ `libmidi.c` `update_ev_timestamp`: add 8192 on backward timestamps, ignore implausible jumps when wall-clock elapsed is small, and reset after a long pause. Timestamp-always-zero devices still fire immediately.
- `lastFireTime` keeps fire times monotonic.

## Test plan
- [x] Unit tests: `./gradlew :BLE-MIDI-library:testDebugUnitTest --tests jp.kshoji.blemidi.util.BleMidiTimestampCoordinatorTest`
- [x] Device check: wrap / sequence timing looked correct after the debug logs were removed
- [x] Sample app smoke: Central / Peripheral clock or note sequence still plays in order

Made with [Cursor](https://cursor.com)