### PR TITLE
Add RPN/NRPN value width tracker

### DIFF
--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/listener/OnMidiInputEventListener.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/listener/OnMidiInputEventListener.java
@@ -162,6 +162,10 @@ public interface OnMidiInputEventListener {
     /**
      * RPN message<br />
      * invoked when value's MSB or LSB changed
+     * <p>
+     * {@code value} is 7 bits or 14 bits. Distinguish them with
+     * {@link jp.kshoji.blemidi.util.RpnNrpnValueWidthTracker} from {@link #onMidiControlChange}
+     * (this callback is queued before the matching Control Change).
      *
      * @param sender the device sent this message
      * @param channel 0-15
@@ -173,6 +177,10 @@ public interface OnMidiInputEventListener {
     /**
      * NRPN message<br />
      * invoked when value's MSB or LSB changed
+     * <p>
+     * {@code value} is 7 bits or 14 bits. Distinguish them with
+     * {@link jp.kshoji.blemidi.util.RpnNrpnValueWidthTracker} from {@link #onMidiControlChange}
+     * (this callback is queued before the matching Control Change).
      *
      * @param sender the device sent this message
      * @param channel 0-15

--- a/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/RpnNrpnValueWidthTracker.java
+++ b/BLE-MIDI-library/src/main/java/jp/kshoji/blemidi/util/RpnNrpnValueWidthTracker.java
@@ -1,0 +1,147 @@
+package jp.kshoji.blemidi.util;
+
+/**
+ * Distinguishes 7-bit vs 14-bit RPN/NRPN Data Entry from
+ * {@link jp.kshoji.blemidi.listener.OnMidiInputEventListener#onMidiControlChange}.
+ * <p>
+ * {@code onRPNMessage} / {@code onNRPNMessage} expose a combined {@code value}
+ * that may be 7 or 14 bits; this tracker uses the Control Change stream that
+ * the parser already delivers for every CC (including 101/100/6/38 and 99/98/6/38).
+ * <p>
+ * Feed every {@code onMidiControlChange} into {@link #onControlChange}, then
+ * read {@link #getValueWidth(int)} when the controller is Data Entry
+ * ({@link #CC_DATA_ENTRY_MSB} or {@link #CC_DATA_ENTRY_LSB}).
+ * Do not query from {@code onRPNMessage}: that callback is queued before the
+ * matching Control Change, so the current CC has not been applied yet.
+ *
+ * @author K.Shoji
+ */
+public final class RpnNrpnValueWidthTracker {
+    public static final int CC_DATA_ENTRY_MSB = 6;
+    public static final int CC_DATA_ENTRY_LSB = 38;
+    public static final int CC_NRPN_LSB = 98;
+    public static final int CC_NRPN_MSB = 99;
+    public static final int CC_RPN_LSB = 100;
+    public static final int CC_RPN_MSB = 101;
+
+    /**
+     * Data Entry width for the current RPN/NRPN on a channel.
+     */
+    public enum ValueWidth {
+        /**
+         * Parameter selected (or idle), but no Data Entry CC yet.
+         */
+        UNKNOWN,
+        /**
+         * Only Data Entry MSB (CC 6) seen since the last parameter select.
+         */
+        BITS_7,
+        /**
+         * Data Entry LSB (CC 38) seen for the current parameter.
+         */
+        BITS_14
+    }
+
+    private final boolean[] sawDataEntryMsb = new boolean[16];
+    private final boolean[] sawDataEntryLsb = new boolean[16];
+
+    /**
+     * @return {@code true} if {@code function} is Data Entry MSB (CC 6)
+     */
+    public static boolean isDataEntryMsb(int function) {
+        return function == CC_DATA_ENTRY_MSB;
+    }
+
+    /**
+     * @return {@code true} if {@code function} is Data Entry LSB (CC 38)
+     */
+    public static boolean isDataEntryLsb(int function) {
+        return function == CC_DATA_ENTRY_LSB;
+    }
+
+    /**
+     * @return {@code true} if {@code function} is Data Entry MSB or LSB
+     */
+    public static boolean isDataEntry(int function) {
+        return isDataEntryMsb(function) || isDataEntryLsb(function);
+    }
+
+    /**
+     * @return {@code true} if {@code function} selects an RPN or NRPN parameter
+     */
+    public static boolean isParameterSelect(int function) {
+        return function == CC_RPN_MSB
+                || function == CC_RPN_LSB
+                || function == CC_NRPN_MSB
+                || function == CC_NRPN_LSB;
+    }
+
+    /**
+     * Updates the per-channel width from one Control Change.
+     *
+     * @param channel  0–15
+     * @param function controller number
+     * @param value    controller value (unused; kept for listener-shaped calls)
+     */
+    public void onControlChange(int channel, int function, int value) {
+        int ch = channel & 0x0f;
+        if (isParameterSelect(function)) {
+            sawDataEntryMsb[ch] = false;
+            sawDataEntryLsb[ch] = false;
+            return;
+        }
+        if (isDataEntryMsb(function)) {
+            sawDataEntryMsb[ch] = true;
+            sawDataEntryLsb[ch] = false;
+            return;
+        }
+        if (isDataEntryLsb(function)) {
+            sawDataEntryLsb[ch] = true;
+        }
+    }
+
+    /**
+     * Width of the current Data Entry on {@code channel}.
+     *
+     * @param channel 0–15
+     * @return {@link ValueWidth#BITS_14} if CC 38 has been seen,
+     *         {@link ValueWidth#BITS_7} if only CC 6 has been seen,
+     *         otherwise {@link ValueWidth#UNKNOWN}
+     */
+    public ValueWidth getValueWidth(int channel) {
+        int ch = channel & 0x0f;
+        if (sawDataEntryLsb[ch]) {
+            return ValueWidth.BITS_14;
+        }
+        if (sawDataEntryMsb[ch]) {
+            return ValueWidth.BITS_7;
+        }
+        return ValueWidth.UNKNOWN;
+    }
+
+    /**
+     * @param channel 0–15
+     * @return {@code true} if the current Data Entry includes CC 38
+     */
+    public boolean is14Bit(int channel) {
+        return getValueWidth(channel) == ValueWidth.BITS_14;
+    }
+
+    /**
+     * @param channel 0–15
+     * @return {@code true} if only Data Entry MSB has been seen
+     */
+    public boolean is7Bit(int channel) {
+        return getValueWidth(channel) == ValueWidth.BITS_7;
+    }
+
+    /**
+     * Clears Data Entry state on every channel.
+     */
+    public void reset() {
+        for (int i = 0; i < 16; i++) {
+            sawDataEntryMsb[i] = false;
+            sawDataEntryLsb[i] = false;
+        }
+    }
+}

--- a/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/RpnNrpnValueWidthTrackerTest.java
+++ b/BLE-MIDI-library/src/test/java/jp/kshoji/blemidi/util/RpnNrpnValueWidthTrackerTest.java
@@ -1,0 +1,125 @@
+package jp.kshoji.blemidi.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RpnNrpnValueWidthTrackerTest {
+
+    @Test
+    public void parameterSelectResetsWidth() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_MSB, 0);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_LSB, 1);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 10);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_LSB, 20);
+
+        assertTrue(tracker.is14Bit(0));
+
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_MSB, 0);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_LSB, 2);
+
+        assertEquals(RpnNrpnValueWidthTracker.ValueWidth.UNKNOWN, tracker.getValueWidth(0));
+        assertFalse(tracker.is7Bit(0));
+        assertFalse(tracker.is14Bit(0));
+    }
+
+    @Test
+    public void dataEntryMsbOnlyIs7Bit() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_MSB, 0);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_LSB, 0);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 64);
+
+        assertTrue(tracker.is7Bit(0));
+        assertFalse(tracker.is14Bit(0));
+        assertEquals(RpnNrpnValueWidthTracker.ValueWidth.BITS_7, tracker.getValueWidth(0));
+    }
+
+    @Test
+    public void dataEntryMsbThenLsbIs14Bit() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(1, RpnNrpnValueWidthTracker.CC_NRPN_MSB, 1);
+        tracker.onControlChange(1, RpnNrpnValueWidthTracker.CC_NRPN_LSB, 2);
+        tracker.onControlChange(1, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 3);
+        assertTrue(tracker.is7Bit(1));
+
+        tracker.onControlChange(1, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_LSB, 4);
+
+        assertTrue(tracker.is14Bit(1));
+        assertFalse(tracker.is7Bit(1));
+        assertEquals(RpnNrpnValueWidthTracker.ValueWidth.BITS_14, tracker.getValueWidth(1));
+    }
+
+    @Test
+    public void dataEntryLsbAloneIs14Bit() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_MSB, 0);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_LSB, 5);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_LSB, 7);
+
+        assertTrue(tracker.is14Bit(0));
+    }
+
+    @Test
+    public void nullRpnResetsWidth() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_MSB, 0);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_LSB, 0);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 1);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_LSB, 2);
+        assertTrue(tracker.is14Bit(0));
+
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_MSB, 0x7f);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_RPN_LSB, 0x7f);
+
+        assertEquals(RpnNrpnValueWidthTracker.ValueWidth.UNKNOWN, tracker.getValueWidth(0));
+    }
+
+    @Test
+    public void channelsAreIndependent() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 1);
+        tracker.onControlChange(2, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 2);
+        tracker.onControlChange(2, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_LSB, 3);
+
+        assertTrue(tracker.is7Bit(0));
+        assertTrue(tracker.is14Bit(2));
+        assertEquals(RpnNrpnValueWidthTracker.ValueWidth.UNKNOWN, tracker.getValueWidth(1));
+    }
+
+    @Test
+    public void subsequentMsbAfter14BitBecomes7Bit() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 10);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_LSB, 20);
+        tracker.onControlChange(0, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 30);
+
+        assertTrue(tracker.is7Bit(0));
+        assertFalse(tracker.is14Bit(0));
+    }
+
+    @Test
+    public void resetClearsAllChannels() {
+        RpnNrpnValueWidthTracker tracker = new RpnNrpnValueWidthTracker();
+        tracker.onControlChange(3, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_MSB, 1);
+        tracker.onControlChange(4, RpnNrpnValueWidthTracker.CC_DATA_ENTRY_LSB, 2);
+        tracker.reset();
+
+        assertEquals(RpnNrpnValueWidthTracker.ValueWidth.UNKNOWN, tracker.getValueWidth(3));
+        assertEquals(RpnNrpnValueWidthTracker.ValueWidth.UNKNOWN, tracker.getValueWidth(4));
+    }
+
+    @Test
+    public void staticHelpersIdentifyControllers() {
+        assertTrue(RpnNrpnValueWidthTracker.isDataEntryMsb(6));
+        assertTrue(RpnNrpnValueWidthTracker.isDataEntryLsb(38));
+        assertTrue(RpnNrpnValueWidthTracker.isDataEntry(6));
+        assertTrue(RpnNrpnValueWidthTracker.isParameterSelect(100));
+        assertTrue(RpnNrpnValueWidthTracker.isParameterSelect(99));
+        assertFalse(RpnNrpnValueWidthTracker.isDataEntry(7));
+        assertFalse(RpnNrpnValueWidthTracker.isParameterSelect(1));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ When the send queue is congested, packing every pending message into one GATT wr
 
 The tradeoff is a small increase in latency under load, in exchange for fewer lost notes / CCs. Tune with `MidiOutputDevice.setMaxMessagesPerPacket(int)` (smaller = more reliable, more latency).
 
+RPN / NRPN value width
+----------------------
+
+`onRPNMessage` / `onNRPNMessage` expose a combined `value` that may be 7-bit or 14-bit. The parser also delivers every RPN/NRPN controller through `onMidiControlChange` (`CC 101/100/6/38` or `CC 99/98/6/38`). To rebuild MIDI bytes, emit those CCs as-is. To tell 7-bit from 14-bit Data Entry, feed each `onMidiControlChange` into `RpnNrpnValueWidthTracker` and read `getValueWidth(channel)` when the controller is CC 6 or CC 38.
+
 LICENSE
 =======
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
## Summary
- Add `RpnNrpnValueWidthTracker` so apps can tell 7-bit vs 14-bit RPN/NRPN Data Entry from the existing `onMidiControlChange` stream (#35).
- Reconstruct MIDI bytes from those CCs (`101/100/6/38` or `99/98/6/38`); do not infer width from the combined `onRPNMessage` / `onNRPNMessage` value.
- Listener javadoc and README note that `onRPNMessage` is queued before the matching Control Change, so width must be read from `onMidiControlChange`.

## Test plan
- [x] Unit tests: `./gradlew :BLE-MIDI-library:testDebugUnitTest --tests jp.kshoji.blemidi.util.RpnNrpnValueWidthTrackerTest`
- [x] Feed the tracker from `onMidiControlChange` and confirm CC 6 only = 7-bit, CC 6 then CC 38 = 14-bit
- [x] Confirm existing `onRPNMessage` / `onNRPNMessage` behavior is unchanged

Made with [Cursor](https://cursor.com)